### PR TITLE
docs: adjust styling of headings

### DIFF
--- a/docs/acctload.html
+++ b/docs/acctload.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/argparse.html
+++ b/docs/argparse.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/cache.html
+++ b/docs/cache.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/cli.html
+++ b/docs/cli.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/cloudwatch.html
+++ b/docs/cloudwatch.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/cmdmgr.html
+++ b/docs/cmdmgr.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/aws/access_report.html
+++ b/docs/commands/aws/access_report.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/aws/aws.html
+++ b/docs/commands/aws/aws.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/aws/cidr_overlap.html
+++ b/docs/commands/aws/cidr_overlap.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/aws/console.html
+++ b/docs/commands/aws/console.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/aws/dx_maint.html
+++ b/docs/commands/aws/dx_maint.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/aws/dx_status.html
+++ b/docs/commands/aws/dx_status.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/aws/index.html
+++ b/docs/commands/aws/index.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/aws/kubectl.html
+++ b/docs/commands/aws/kubectl.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/aws/last.html
+++ b/docs/commands/aws/last.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/aws/list_hosted_zones.html
+++ b/docs/commands/aws/list_hosted_zones.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/aws/list_iam_policies.html
+++ b/docs/commands/aws/list_iam_policies.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/aws/list_iam_roles.html
+++ b/docs/commands/aws/list_iam_roles.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/aws/list_igws.html
+++ b/docs/commands/aws/list_igws.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/aws/list_lambdas.html
+++ b/docs/commands/aws/list_lambdas.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/aws/list_public_ips.html
+++ b/docs/commands/aws/list_public_ips.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/aws/list_vpc_attribute.html
+++ b/docs/commands/aws/list_vpc_attribute.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/aws/list_vpcs.html
+++ b/docs/commands/aws/list_vpcs.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/azure/az.html
+++ b/docs/commands/azure/az.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/azure/cidr_overlap.html
+++ b/docs/commands/azure/cidr_overlap.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/azure/index.html
+++ b/docs/commands/azure/index.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/azure/list_udrs.html
+++ b/docs/commands/azure/list_udrs.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/azure/list_vnets.html
+++ b/docs/commands/azure/list_vnets.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/commands/index.html
+++ b/docs/commands/index.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/config.html
+++ b/docs/config.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/plugins/accts/azure.html
+++ b/docs/plugins/accts/azure.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/plugins/accts/index.html
+++ b/docs/plugins/accts/index.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/plugins/creds/aws.html
+++ b/docs/plugins/creds/aws.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/plugins/creds/azure.html
+++ b/docs/plugins/creds/azure.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/plugins/creds/index.html
+++ b/docs/plugins/creds/index.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/plugins/index.html
+++ b/docs/plugins/index.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/plugmgr.html
+++ b/docs/plugmgr.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/runner.html
+++ b/docs/runner.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/session/aws.html
+++ b/docs/session/aws.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/session/azure.html
+++ b/docs/session/azure.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/docs/session/index.html
+++ b/docs/session/index.html
@@ -15,7 +15,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 body {
 font-size: 16px;
@@ -53,14 +53,14 @@ font-size: 14px;
 code.name {
 font-size: 14px;
 }
+.title code {
+font-family: 'Roboto', sans-serif;
+}
 dt {
 font-weight: bold;
 }
 h1 {
 font-size: 2.0em;
-}
-h4 {
-font-weight: bold;
 }
 </style>
 </head>

--- a/src/docs/templates/head.mako
+++ b/src/docs/templates/head.mako
@@ -1,7 +1,7 @@
 <!-- <link href="/awsrun/webfonts.css" rel="stylesheet"> -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,400;0,700;1,400;1,700&family=Roboto:ital,wght@0,300;0,400;0,700;1,400;1,700&display=swap" rel="stylesheet">
 <style>
 
 body {
@@ -49,15 +49,15 @@ code.name {
     font-size: 14px;
 }
 
+.title code {
+    font-family: 'Roboto', sans-serif;
+}
+
 dt {
     font-weight: bold;
 }
 
 h1 {
     font-size: 2.0em;
-}
-
-h4 {
-    font-weight: bold;
 }
 </style>


### PR DESCRIPTION
Two changes:

1. Use non-monospace font for module name at top of each page.
2. Use light headings (Roboto Mono Light looks nice imho).