### PR TITLE
build!: slim default install with optional deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,17 +106,17 @@ Python 3.7 or higher is required.
 
 To install:
 
-    $ pip install awsrun[aws,azure]
+    $ pip install "awsrun[aws,azure]"
 
 This will install dependencies for both `awsrun` and `azurerun`.
 If you don't want both, you can specify only one. For example,
 if you only want `awsrun`:
 
-    $ pip install awsrun[aws]
+    $ pip install "awsrun[aws]"
 
 If you only want `azurerun`:
 
-    $ pip install awsrun[azure]
+    $ pip install "awsrun[azure]"
 
 In all three cases, the console scripts `awsrun` and `azurerun` are
 installed, but only the dependencies for the specified CSP are installed.
@@ -135,6 +135,18 @@ Note: In order to use the built-in azurerun
 CLI tool must be
 [installed](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
 and available in your operating system's PATH.
+
+Some of the bundled sample commands have additional dependencies, which are
+not installed by default. You'll be prompted when attempting to run one of
+them if you need to install additional packages. If you'd prefer, you can install
+all of the additional command dependencies:
+
+    $ pip install "awsrun[cmds]"
+
+Or specific commands by choosing the appropriate optional dependency. For example,
+to install the packages needed by the `last` command:
+
+    $ pip install "awsrun[last]"
 
 To install from source, clone the repo and run pip install:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "awsrun"
-authors = [{name = "Pete Kazmier", email = "opensource@fidelity.com"}]
+authors = [{ name = "Pete Kazmier", email = "opensource@fidelity.com" }]
 description = "CLI and library to execute commands over one or more AWS or Azure accounts concurrently."
 readme = "README.md"
 requires-python = ">=3.7"
 keywords = ["aws", "azure", "cli", "command runner"]
-license = {file = "LICENSE"}
+license = { file = "LICENSE" }
 dynamic = ["version"]
 
 classifiers = [
@@ -31,26 +31,23 @@ classifiers = [
   "Topic :: Utilities",
 ]
 
-dependencies = [
-  "PyYAML>=3.10",
-  "requests",
-  "requests_file",
-  "requests_ntlm",
-]
+# mandatory dependencies
+dependencies = ["PyYAML>=3.10", "requests", "requests_file", "requests_ntlm"]
 
 [project.optional-dependencies]
-aws = [
-  "asciichartpy>=1.5.25",
-  "boto3>=1.12.39",
-  "bs4",
-  "colorama",
-  "py_cui==0.1.6",
-  "pysparklines>=1.0",
-]
-azure = [
-  "azure-identity",
-  "azure-mgmt-network",
-]
+all = ["awsrun[aws,azure,cmds,dev]"]
+
+# dependencies for supported CSPs
+aws = ["boto3>=1.12.39", "bs4"]
+azure = ["azure-identity", "azure-mgmt-network"]
+
+# dependencies for bundled commands
+cmds = ["awsrun[last,dx-maint,dx-status]"]
+last = ["pyperclip", "colorama", "rich", "textual==0.16"]
+dx-maint = ["colorama"]
+dx-status = ["colorama", "asciichartpy>=1.5.25", "pysparklines>=1.0"]
+
+# dependencies for development
 dev = [
   "black",
   "flake8",
@@ -69,4 +66,4 @@ azurerun = "awsrun.cli:main"
 homepage = "https://github.com/fidelity/awsrun"
 
 [tool.setuptools.dynamic]
-version = {attr = "awsrun.__version__"}
+version = { attr = "awsrun.__version__" }

--- a/src/awsrun/commands/aws/dx_maint.py
+++ b/src/awsrun/commands/aws/dx_maint.py
@@ -86,11 +86,23 @@ import re
 import sys
 from datetime import datetime, timedelta
 
-import colorama
-from colorama import Fore, Style
-
 from awsrun.config import Bool, Int, List, Str
 from awsrun.runner import RegionalCommand, get_paginated_resources
+
+try:
+    import colorama
+    from colorama import Fore, Style
+
+except ImportError:
+    sys.exit(
+        """
+The 'dx_maint' command requires dependencies not installed by default with
+awsrun. Please install them with the following command:
+
+    pip install awsrun[dx-maint]
+"""
+    )
+
 
 LOG = logging.getLogger(__name__)
 

--- a/src/awsrun/commands/aws/dx_status.py
+++ b/src/awsrun/commands/aws/dx_status.py
@@ -170,14 +170,25 @@ import re
 import sys
 from collections import defaultdict
 
-import colorama
-from asciichartpy import plot
-from colorama import Fore, Style
-from sparkline import sparkify
-
 from awsrun.cloudwatch import CWMetrics
 from awsrun.config import Bool, Choice, Type
 from awsrun.runner import RegionalCommand
+
+try:
+    import colorama
+    from asciichartpy import plot
+    from colorama import Fore, Style
+    from sparkline import sparkify
+
+except ImportError:
+    sys.exit(
+        """
+The 'dx_status' command requires dependencies not installed by default with
+awsrun. Please install them with the following command:
+
+    pip install awsrun[dx-status]
+"""
+    )
 
 
 class CLICommand(RegionalCommand):

--- a/src/awsrun/commands/aws/last.py
+++ b/src/awsrun/commands/aws/last.py
@@ -152,7 +152,6 @@ from awsrun.runner import RegionalCommand
 
 try:
     import pyperclip
-    import textual
     from colorama import Fore, Style, init
     from rich.markdown import Markdown
     from rich.syntax import Syntax
@@ -162,17 +161,13 @@ try:
     from textual.reactive import reactive
     from textual.widgets import Button, DataTable, Footer, Header, Input, Static
 
-    if not textual.__version__.startswith("0.16."):
-        raise ImportError("Only textual==0.16 is supported.")
-
-except ImportError as e:
+except ImportError:
     sys.exit(
-        f"""{e}
+        """
+The 'last' command requires dependencies not installed by default with
+awsrun. Please install them with the following command:
 
-This command requires dependencies not installed by default with awsrun.
-Please install the following to use the this command:
-
-    pip install pyperclip colorama rich "textual==0.16"
+    pip install awsrun[last]
 """
     )
 


### PR DESCRIPTION
Previously, all dependencies needed for awsrun, azurerun, and all of the bundled sample commands were installed when doing:

    $ pip install awsrun

With this commit, only the bare minimum is installed. Users MUST now opt-in to the dependencies they might need.  This is a breaking change as the previous command will no longer suffice.

At a minimum, all users will need to specify either "aws" and/or "azure". For example, to install awsrun:

    $ pip install "awsrun[aws]"

Or to install dependencies needed for both awsrun and azurerun:

    $ pip install "awsrun[aws,azure]"

Additionally, several of the included sample commands have additional dependencies that are no longer installed. If you attempt to use one of those commands, but have not installed the optional deps, you will be asked to install them with instructions on how to do so. For example, to install the dependencies for the `last` command (CloudTrail event viewer):

    $ pip install "awsrun[last]"

To install all of the optional dependencies for the included commands, you can also do the following (assuming you already installed either "aws" and/or "azure"):

    $ pip install "awsrun[cmds]"