### PR TITLE
feat: new account loader plugin with http auth

### DIFF
--- a/src/awsrun/cloudwatch.py
+++ b/src/awsrun/cloudwatch.py
@@ -29,6 +29,7 @@ invoking the callable returned by `CWMetrics.add_metric`. For example:
         print(datetime, value)
 
 """
+
 import logging
 import math
 from collections import defaultdict

--- a/src/awsrun/commands/aws/list_lambdas.py
+++ b/src/awsrun/commands/aws/list_lambdas.py
@@ -102,7 +102,7 @@ class CLICommand(RegionalCommand):
                 total = len(by_role[role])
                 public = len([fn for fn in by_role[role] if _is_public(fn)])
                 print(
-                    f"{acct}/{region}: role={role} total={total} private={total-public} public={public}",
+                    f"{acct}/{region}: role={role} total={total} private={total - public} public={public}",
                     file=out,
                 )
 


### PR DESCRIPTION
The existing account loaders in the awsrun.acctload and their respective
CLI-counterparts in awsrun.plugins.accts do not support HTTP auth:

- awsrun.acctload.JSONAccountLoader (awsrun.plugins.accts.JSON)
- awsrun.acctload.YAMLAccountLoader (awsrun.plugins.accts.YAML)
- awsrun.acctload.CSVAccountLoader  (awsrun.plugins.accts.CSV)

This change introduces a new account loader, which will eventually
replace those mentioned above:

- awsrun.acctload.URLAccountLoader  (awsrun.plugins.accts.URLLoader)

The new loader can parse JSON, YAML, and CSV data depending on the
parser provided (library usage) or parser specified via the `parser`
configuration key (CLI usage).

In addition, the new loader supports HTTP basic, digest, ntlm, and
oauth2 authentication methods depending on the auth method provided
(library usage) or auth method specified via the `auth` configuration
key (CLI usage).

Sample usage via the library:

    # Library usage
    from awsrun.acctload import *

    # JSON example with basic HTTP auth
    loader = URLAccountLoader(
        "https://example.com/data.json",
        parser=JSONFormatter(),
        auth=HTTPBasic(user, pw),
    )

    # CSV example with OAuth2 HTTP auth
    loader = URLAccountLoader(
        "https://example.com/data.csv",
        parser=CSVFormatter(delimiter=","),
        auth=HTTPOAuth2("https://token.example.com", user, pw),
    )


Sample usage via the CLI configuration file:

    Accounts:
      plugin: awsrun.plugins.accts.URLLoader
      options:
        url: https://example.com/data.json
        parser: json
        auth: oauth2
        auth_options:
          token_url: https://token.example.com
