### PR TITLE
feat: add new pre_hook_with_context method to Command

### DIFF
--- a/src/awsrun/cli.py
+++ b/src/awsrun/cli.py
@@ -758,10 +758,10 @@ the command.
     """.strip()
 
 
-class CLIContext:
+class Context:
     """Used when `Command.pre_hook_with_context` is invoked.
-     
-    The `CLIContext` provides a `Command` access to awsrun information/context prior to any
+
+    The `Context` provides a `Command` access to awsrun information/context prior to any
     accounts being processed by `Runner`.
 
     """
@@ -1091,12 +1091,13 @@ def _cli(csp):
     # This is the main entry point into the awsrun library. Note: the entirety of
     # awsrun can be used without the need of the CLI. One only needs a list of
     # accounts, an awsrun.runner.Command, and an awsrun.session.SessionProvider.
-    runner = AccountRunner(
-        session_provider,
-        args.threads,
-        context=CLIContext(session_provider, account_loader, accounts),
+    runner = AccountRunner(session_provider, args.threads)
+    elapsed = runner.run(
+        command,
+        accounts,
+        key=account_loader.acct_id,
+        context=Context(session_provider, account_loader, accounts),
     )
-    elapsed = runner.run(command, accounts, key=account_loader.acct_id)
 
     # Show a quick summary on how long the command took to run.
     pluralize = "s" if len(accounts) != 1 else ""

--- a/src/awsrun/cli.py
+++ b/src/awsrun/cli.py
@@ -758,20 +758,6 @@ the command.
     """.strip()
 
 
-class Context:
-    """Used when `Command.pre_hook_with_context` is invoked.
-
-    The `Context` provides a `Command` access to awsrun information/context prior to any
-    accounts being processed by `Runner`.
-
-    """
-
-    def __init__(self, session_provider, account_loader, accounts):
-        self.session_provider = session_provider
-        self.account_loader = account_loader
-        self.accounts = accounts
-
-
 # setup.py establishes this as the entry point for the awsrun CLI.
 def main():
     """The main entry point for the `*run` CLI tool installed with this package.
@@ -1196,6 +1182,20 @@ class _CSP:
     def default_session_provider(self):
         """Returns the module name of the builtin Profile session provider."""
         return "awsrun.plugins.creds." + self.name.lower() + ".Default"
+
+
+class Context:
+    """Used when `Command.pre_hook_with_context` is invoked.
+
+    The `Context` provides a `Command` access to awsrun information/context prior to any
+    accounts being processed by `Runner`.
+
+    """
+
+    def __init__(self, session_provider, account_loader, accounts):
+        self.session_provider = session_provider
+        self.account_loader = account_loader
+        self.accounts = accounts
 
 
 if __name__ == "__main__":

--- a/src/awsrun/cli.py
+++ b/src/awsrun/cli.py
@@ -728,6 +728,7 @@ from pathlib import Path
 
 from awsrun import __version__
 from awsrun.acctload import AccountLoader
+from awsrun.runner import Context
 from awsrun.argparse import (
     AppendAttributeValuePair,
     AppendWithoutDefault,
@@ -1077,7 +1078,11 @@ def _cli(csp):
     # This is the main entry point into the awsrun library. Note: the entirety of
     # awsrun can be used without the need of the CLI. One only needs a list of
     # accounts, an awsrun.runner.Command, and an awsrun.session.SessionProvider.
-    runner = AccountRunner(session_provider, args.threads)
+    runner = AccountRunner(
+        session_provider,
+        args.threads,
+        context=Context(session_provider, account_loader, accounts),
+    )
     elapsed = runner.run(command, accounts, key=account_loader.acct_id)
 
     # Show a quick summary on how long the command took to run.

--- a/src/awsrun/cli.py
+++ b/src/awsrun/cli.py
@@ -728,7 +728,6 @@ from pathlib import Path
 
 from awsrun import __version__
 from awsrun.acctload import AccountLoader
-from awsrun.runner import Context
 from awsrun.argparse import (
     AppendAttributeValuePair,
     AppendWithoutDefault,
@@ -757,6 +756,20 @@ displayed by omitting the command.  Each command can have its own set
 of command line arguments, which can be viewed by passing --help after
 the command.
     """.strip()
+
+
+class CLIContext:
+    """Used when `Command.pre_hook_with_context` is invoked.
+     
+    The `CLIContext` provides a `Command` access to awsrun information/context prior to any
+    accounts being processed by `Runner`.
+
+    """
+
+    def __init__(self, session_provider, account_loader, accounts):
+        self.session_provider = session_provider
+        self.account_loader = account_loader
+        self.accounts = accounts
 
 
 # setup.py establishes this as the entry point for the awsrun CLI.
@@ -1081,7 +1094,7 @@ def _cli(csp):
     runner = AccountRunner(
         session_provider,
         args.threads,
-        context=Context(session_provider, account_loader, accounts),
+        context=CLIContext(session_provider, account_loader, accounts),
     )
     elapsed = runner.run(command, accounts, key=account_loader.acct_id)
 

--- a/src/awsrun/runner.py
+++ b/src/awsrun/runner.py
@@ -326,7 +326,7 @@ class Command:
         before any account processing starts.
 
         This method is invoked in the event a command does not override the default
-        implementation of `AccountRunner.pre_hook_with_context`. In that case, the method
+        implementation of `AccountRunner.pre_hook_with_context`. The method
         is not executed before each account is processed, but rather once before any
         accounts are processed.
 
@@ -832,20 +832,6 @@ def get_paginated_resources(
     return resources
 
 
-class Context:
-    """Used when `Command.pre_hook_with_context` is invoked.
-     
-    The `Context` provides a `Command` access to awsrun information/context prior to any
-    accounts being processed by `Runner`.
-
-    """
-
-    def __init__(self, session_provider, account_loader, accounts):
-        self.session_provider = session_provider
-        self.account_loader = account_loader
-        self.accounts = accounts
-
-
 class AccountRunner:
     """Runs a `Command` across one or more accounts.
 
@@ -875,7 +861,7 @@ class AccountRunner:
         self.max_workers = max_workers
         self.context = context
 
-    def run(self, cmd, accounts, key=lambda x: x, context=None):
+    def run(self, cmd, accounts, key=lambda x: x):
         """Execute a command concurrently on the specified accounts.
 
         This method will block until all accounts have been processed. The

--- a/src/awsrun/runner.py
+++ b/src/awsrun/runner.py
@@ -313,7 +313,7 @@ class Command:
 
         This method is invoked only once per invocation of `AccountRunner.run`.
         The `context` parameter is the opaque object passed as the context
-        parameter `AccountRunner.run`. It is intended to provide access to
+        parameter to `AccountRunner.run`. It is intended to provide access to
         additional runtime context information for the command to leverage.
         The method is not executed before each account is processed, but
         rather once before any accounts are processed.


### PR DESCRIPTION
This PR is intended to address a use case where command authors require access to objects not currently exposed by the runner.

For CLI usage, the following objects have been made available to command authors if they choose to override the pre_hook_with_context method in their command:

- SessionProvider interface (includes creds and session attributes)
- accounts (includes the list of targeted Azure subscriptions)
- account loader plugins

Sample usage via the library:

# Command usage
```python
def pre_hook_with_context(self, context):
     pass
```
